### PR TITLE
DetailView, HomeView 이슈 해결

### DIFF
--- a/Mollection/Mollection/Data/MediaInfo.swift
+++ b/Mollection/Mollection/Data/MediaInfo.swift
@@ -9,7 +9,13 @@ import Foundation
 
 struct MediaInfo: Identifiable {
     var id = UUID()
-    var mediaInfo: MediaVO
-    var documentID: String
+//    var mediaInfo: MediaVO
+//    var documentID: String
+    var media: [Media]
     var category: String
+}
+
+struct Media {
+    var documentID: String
+    var mediaInfo: MediaVO
 }

--- a/Mollection/Mollection/Data/MediaInfo.swift
+++ b/Mollection/Mollection/Data/MediaInfo.swift
@@ -9,8 +9,6 @@ import Foundation
 
 struct MediaInfo: Identifiable {
     var id = UUID()
-//    var mediaInfo: MediaVO
-//    var documentID: String
     var media: [Media]
     var category: String
 }

--- a/Mollection/Mollection/Network/Firebase/FBStore.swift
+++ b/Mollection/Mollection/Network/Firebase/FBStore.swift
@@ -71,7 +71,7 @@ final class FBStore: ObservableObject {
             .addDocument(data: data)
     }
     
-    func getMediaData(category: String) {
+    func getMediaData(category: String, completion: @escaping () -> Void = {}) {
         guard let uid = UserManager.uid else {return}
         
         db.collection(FireStoreID.Users.rawValue).document(uid).collection(FireStoreID.media.rawValue)
@@ -83,8 +83,7 @@ final class FBStore: ObservableObject {
                     print("no document")
                     return
                 }
-                
-//                self?.mediaInfos.removeAll()
+
                 if let index = self?.mediaInfos.firstIndex(where: { $0.category == category} ) {
                     self?.mediaInfos.remove(at: index)
                 }
@@ -107,19 +106,7 @@ final class FBStore: ObservableObject {
                 }
                 
                 self?.mediaInfos.append(MediaInfo(media: media, category: category))
-//                (MediaInfo(
-//                    mediaInfo: MediaVO(
-//                        id: document.data()[FireStoreMedia.id.rawValue] as! Int,
-//                        backdropPath: document.data()[FireStoreMedia.backdropPath.rawValue] as? String,
-//                        posterPath: document.data()[FireStoreMedia.posterPath.rawValue] as? String,
-//                        title: document.data()[FireStoreMedia.title.rawValue] as? String,
-//                        releaseDate: document.data()[FireStoreMedia.releaseDate.rawValue] as? String,
-//                        overview: document.data()[FireStoreMedia.overview.rawValue] as? String,
-//                        voteAverage: document.data()[FireStoreMedia.voteAverage.rawValue] as? Double,
-//                        mediaType: MediaType(rawValue: document.data()[FireStoreMedia.mediaType.rawValue] as! String) ?? .movie,
-//                        genreIDS: document.data()[FireStoreMedia.genreIDS.rawValue] as? [Int]),
-//                    documentID: document.documentID,
-//                    category: document.data()[FireStoreMedia.category.rawValue] as! String))
+                completion()
             }
     }
     

--- a/Mollection/Mollection/Network/Firebase/FBStore.swift
+++ b/Mollection/Mollection/Network/Firebase/FBStore.swift
@@ -84,10 +84,16 @@ final class FBStore: ObservableObject {
                     return
                 }
                 
-                self?.mediaInfos.removeAll()
+//                self?.mediaInfos.removeAll()
+                if let index = self?.mediaInfos.firstIndex(where: { $0.category == category} ) {
+                    self?.mediaInfos.remove(at: index)
+                }
+                
+                var media: [Media] = []
                 
                 for document in documents {
-                    self?.mediaInfos.append(MediaInfo(
+                    media.append(Media(
+                        documentID: document.documentID,
                         mediaInfo: MediaVO(
                             id: document.data()[FireStoreMedia.id.rawValue] as! Int,
                             backdropPath: document.data()[FireStoreMedia.backdropPath.rawValue] as? String,
@@ -97,10 +103,23 @@ final class FBStore: ObservableObject {
                             overview: document.data()[FireStoreMedia.overview.rawValue] as? String,
                             voteAverage: document.data()[FireStoreMedia.voteAverage.rawValue] as? Double,
                             mediaType: MediaType(rawValue: document.data()[FireStoreMedia.mediaType.rawValue] as! String) ?? .movie,
-                            genreIDS: document.data()[FireStoreMedia.genreIDS.rawValue] as? [Int]),
-                        documentID: document.documentID,
-                        category: document.data()[FireStoreMedia.category.rawValue] as! String))
+                            genreIDS: document.data()[FireStoreMedia.genreIDS.rawValue] as? [Int])))
                 }
+                
+                self?.mediaInfos.append(MediaInfo(media: media, category: category))
+//                (MediaInfo(
+//                    mediaInfo: MediaVO(
+//                        id: document.data()[FireStoreMedia.id.rawValue] as! Int,
+//                        backdropPath: document.data()[FireStoreMedia.backdropPath.rawValue] as? String,
+//                        posterPath: document.data()[FireStoreMedia.posterPath.rawValue] as? String,
+//                        title: document.data()[FireStoreMedia.title.rawValue] as? String,
+//                        releaseDate: document.data()[FireStoreMedia.releaseDate.rawValue] as? String,
+//                        overview: document.data()[FireStoreMedia.overview.rawValue] as? String,
+//                        voteAverage: document.data()[FireStoreMedia.voteAverage.rawValue] as? Double,
+//                        mediaType: MediaType(rawValue: document.data()[FireStoreMedia.mediaType.rawValue] as! String) ?? .movie,
+//                        genreIDS: document.data()[FireStoreMedia.genreIDS.rawValue] as? [Int]),
+//                    documentID: document.documentID,
+//                    category: document.data()[FireStoreMedia.category.rawValue] as! String))
             }
     }
     

--- a/Mollection/Mollection/Presentation/TabScene/Common/DetailScene/DetailView.swift
+++ b/Mollection/Mollection/Presentation/TabScene/Common/DetailScene/DetailView.swift
@@ -12,11 +12,12 @@ struct DetailView: View {
     @StateObject private var viewModel: DetailViewModel
     
     var mediaData: MediaVO
-    var documentID: String? = nil
+    var documentID: String?
     
-    init(fbStore: FBStore, mediaData: MediaVO, documentID: String? = nil) {
+    init(fbStore: FBStore, mediaData: MediaVO, documentID: String?) {
         self._viewModel = StateObject(wrappedValue: DetailViewModel(fbStore: fbStore, mediaData: mediaData))
         self.mediaData = mediaData
+        self.documentID = documentID
     }
     
     var body: some View {
@@ -151,6 +152,6 @@ extension DetailView {
 
 struct DetailView_Previews: PreviewProvider {
     static var previews: some View {
-        DetailView(fbStore: FBStore(), mediaData: MediaVO(id: 1, mediaType: .movie))
+        DetailView(fbStore: FBStore(), mediaData: MediaVO(id: 1, mediaType: .movie), documentID: nil)
     }
 }

--- a/Mollection/Mollection/Presentation/TabScene/Common/DetailScene/ViewModel/DetailViewModel.swift
+++ b/Mollection/Mollection/Presentation/TabScene/Common/DetailScene/ViewModel/DetailViewModel.swift
@@ -87,12 +87,7 @@ final class DetailViewModel: ObservableObject {
         } else {
             isactiveAlert = .duplicated
         }
-        
-//        if fbStore.mediaInfos.filter({$0.mediaInfo.id == mediaData.id}).isEmpty {
-//            isactiveAlert = .normal
-//        } else {
-//            isactiveAlert = .duplicated
-//        }
+    
         isShowAlert = true
     }
     

--- a/Mollection/Mollection/Presentation/TabScene/Common/DetailScene/ViewModel/DetailViewModel.swift
+++ b/Mollection/Mollection/Presentation/TabScene/Common/DetailScene/ViewModel/DetailViewModel.swift
@@ -78,11 +78,21 @@ final class DetailViewModel: ObservableObject {
     
     func pickerBindingSet(index: Int) {
         selectionIndex = index
-        if fbStore.mediaInfos.filter({$0.mediaInfo.id == mediaData.id}).isEmpty {
-            isactiveAlert = .normal
+        if let firstIndex = fbStore.mediaInfos.firstIndex(where: {$0.category == fbStore.categoryInfo[index].category}) {
+            if fbStore.mediaInfos[firstIndex].media.filter({$0.mediaInfo.id == mediaData.id}).isEmpty {
+                isactiveAlert = .normal
+            } else {
+                isactiveAlert = .duplicated
+            }
         } else {
             isactiveAlert = .duplicated
-        } // 고쳐야함
+        }
+        
+//        if fbStore.mediaInfos.filter({$0.mediaInfo.id == mediaData.id}).isEmpty {
+//            isactiveAlert = .normal
+//        } else {
+//            isactiveAlert = .duplicated
+//        }
         isShowAlert = true
     }
     

--- a/Mollection/Mollection/Presentation/TabScene/HomeScene/HomeView.swift
+++ b/Mollection/Mollection/Presentation/TabScene/HomeScene/HomeView.swift
@@ -20,7 +20,7 @@ struct HomeView: View {
     var body: some View {
         ScrollView {
             LazyVGrid(columns: columns, spacing: 15) {
-                ForEach(fbStore.mediaInfos, id: \.id) { data in
+                ForEach(viewModel.media ?? [], id: \.documentID) { data in
                     NavigationLink {
                         DetailView(fbStore: fbStore, mediaData: data.mediaInfo, documentID: data.documentID)
                     } label: {

--- a/Mollection/Mollection/Presentation/TabScene/HomeScene/ViewModel/HomeViewModel.swift
+++ b/Mollection/Mollection/Presentation/TabScene/HomeScene/ViewModel/HomeViewModel.swift
@@ -22,10 +22,11 @@ final class HomeViewModel: ObservableObject {
     func categoryChange() {
         subject.sink { [weak self] value in
             self?.navigationTitle = value
-            self?.fbStore.getMediaData(category: value)
-            if let index = self?.fbStore.mediaInfos.firstIndex(where: {$0.category == value}) {
-                self?.media = self?.fbStore.mediaInfos[index].media
-            }
+            self?.fbStore.getMediaData(category: value, completion: {
+                if let index = self?.fbStore.mediaInfos.firstIndex(where: {$0.category == value}) {
+                    self?.media = self?.fbStore.mediaInfos[index].media
+                }
+            })
         }
         .store(in: &cancellables)
     }

--- a/Mollection/Mollection/Presentation/TabScene/HomeScene/ViewModel/HomeViewModel.swift
+++ b/Mollection/Mollection/Presentation/TabScene/HomeScene/ViewModel/HomeViewModel.swift
@@ -13,6 +13,7 @@ final class HomeViewModel: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
     let subject = CurrentValueSubject<String, Never>("Mollection")
     private(set) var fbStore: FBStore
+    private(set) var media: [Media]?
     
     init(fbStore: FBStore) {
         self.fbStore = fbStore
@@ -22,6 +23,9 @@ final class HomeViewModel: ObservableObject {
         subject.sink { [weak self] value in
             self?.navigationTitle = value
             self?.fbStore.getMediaData(category: value)
+            if let index = self?.fbStore.mediaInfos.firstIndex(where: {$0.category == value}) {
+                self?.media = self?.fbStore.mediaInfos[index].media
+            }
         }
         .store(in: &cancellables)
     }

--- a/Mollection/Mollection/Presentation/TabScene/SearchScene/SearchView.swift
+++ b/Mollection/Mollection/Presentation/TabScene/SearchScene/SearchView.swift
@@ -61,7 +61,7 @@ struct SearchView: View {
         }
         .navigationDestination(isPresented: $isShowingDetail) {
             if let mediaData = mediaData {
-                DetailView(fbStore: fbStore, mediaData: mediaData)
+                DetailView(fbStore: fbStore, mediaData: mediaData, documentID: nil)
             }
         }
     }


### PR DESCRIPTION
## DetailView
- 중복 저장, 카테고리 별 저장 이슈
  - media model 변경
  - firestore에서 media 정보 category 별로 get, 이중 배열 형태

## HomeView
- firestore에서 media 정보 get 해오는 시점과 media 정보가 담긴 배열 filter 처리 시점이 맞지 않는 이슈
  - firestore에서 media 정보 get 해오는 함수 @escaping closure를 사용해 시점 맞춤